### PR TITLE
Inductor and OpAmp Components

### DIFF
--- a/examples/test.py
+++ b/examples/test.py
@@ -6,61 +6,66 @@ class test(Scene):
 	def construct(self):
 		self.wait(0.1)
 
-		r1 = Battery()
-		r2 = Resistor()
-		c = Capacitor()
-		bjt_npn = BJT_NPN()
+		opamp = OpAmp().shift(DOWN*2).scale(0.5).update()
+		bjt = BJT_NPN().shift(UP*2).scale(0.5).update()
+
+		self.play(Create(opamp),Create(bjt), run_time=5)
+
+		# r1 = Battery()
+		# r2 = Resistor()
+		# c = Capacitor()
+		# bjt_npn = BJT_NPN()
 
 
-		bjt_npn.shift(UP*2).scale(0.5)
-		r1.shift(DOWN*2).rotate(PI).scale(0.5)
-		r2.shift(LEFT*3).rotate(PI/2).scale(0.5)
-		c.shift(RIGHT*3).rotate(-PI/2).scale(0.5)
+		# bjt_npn.shift(UP*2).scale(0.5)
+		# r1.shift(DOWN*2).rotate(PI).scale(0.5)
+		# r2.shift(LEFT*3).rotate(PI/2).scale(0.5)
+		# c.shift(RIGHT*3).rotate(-PI/2).scale(0.5)
 
-		hw1,vw1=connect_with_square_wire(c, 'left', bjt_npn, 'collector', 'y')
-		hw2,vw2=connect_with_square_wire(c, 'right', r1, 'negative', 'x')
-		hw3,vw3=connect_with_square_wire(r2, 'left', r1, 'positive', 'y')
-		hw4,vw4=connect_with_square_wire(r2, 'right', bjt_npn, 'emitter', 'x')
-		cElems = [bjt_npn,hw1,vw1,c,vw2,hw2,r1,hw3,vw3,r2,vw4,hw4]
+		# hw1,vw1=connect_with_square_wire(c, 'left', bjt_npn, 'collector', 'y')
+		# hw2,vw2=connect_with_square_wire(c, 'right', r1, 'negative', 'x')
+		# hw3,vw3=connect_with_square_wire(r2, 'left', r1, 'positive', 'y')
+		# hw4,vw4=connect_with_square_wire(r2, 'right', bjt_npn, 'emitter', 'x')
+		# cElems = [bjt_npn,hw1,vw1,c,vw2,hw2,r1,hw3,vw3,r2,vw4,hw4]
 
-		for cElem in cElems:
-			cElem.update()
+		# for cElem in cElems:
+		# 	cElem.update()
 
 
-		for wire in [hw1, vw1, hw2, vw2, hw3, vw3, hw4, vw4]:
-			wire.scale(0.5)
-			wire.update()
+		# for wire in [hw1, vw1, hw2, vw2, hw3, vw3, hw4, vw4]:
+		# 	wire.scale(0.5)
+		# 	wire.update()
 
 			
-		hw0, hw1 = split_wire(hw1, 0.2)
-		hw0.bind_terminal('right', bjt_npn, 'collector', Y_AXIS)
-		hw1.bind_terminal('left', bjt_npn, 'collector', Y_AXIS)
+		# hw0, hw1 = split_wire(hw1, 0.2)
+		# hw0.bind_terminal('right', bjt_npn, 'collector', Y_AXIS)
+		# hw1.bind_terminal('left', bjt_npn, 'collector', Y_AXIS)
 
-		r3 = Resistor()
-		r3.rotate(-PI/2).scale(0.5).shift([hw0.get_terminal_coord('right')[0] - r3.get_terminal_coord('left')[0], 0, 0])
-		w0 = connect_with_straight_wire(hw0, 'right', r3, 'left')
-		w1 = Wire()
-		w0=w0.scale(0.5)
-		w1=w1.scale(0.5)
-		w1.set_terminal_coordinate('left', r3.get_terminal_coord('right'))
-		w1.set_terminal_coordinate('right', [r3.get_terminal_coord('right')[0], r1.get_center()[1], r3.get_terminal_coord('right')[2]])
+		# r3 = Resistor()
+		# r3.rotate(-PI/2).scale(0.5).shift([hw0.get_terminal_coord('right')[0] - r3.get_terminal_coord('left')[0], 0, 0])
+		# w0 = connect_with_straight_wire(hw0, 'right', r3, 'left')
+		# w1 = Wire()
+		# w0=w0.scale(0.5)
+		# w1=w1.scale(0.5)
+		# w1.set_terminal_coordinate('left', r3.get_terminal_coord('right'))
+		# w1.set_terminal_coordinate('right', [r3.get_terminal_coord('right')[0], r1.get_center()[1], r3.get_terminal_coord('right')[2]])
 
-		cElems = [bjt_npn,hw0,hw1,vw1,c,vw2,hw2,r1,hw3,vw3,r2,vw4,hw4, w0,r3,w1]
-		for cElem in cElems:
-			cElem.update()
-			self.play(Create(cElem))
+		# cElems = [bjt_npn,hw0,hw1,vw1,c,vw2,hw2,r1,hw3,vw3,r2,vw4,hw4, w0,r3,w1]
+		# for cElem in cElems:
+		# 	cElem.update()
+		# 	self.play(Create(cElem))
 
-		self.play(
-			bjt_npn.animate.shift(DOWN*0.5+LEFT),
-			c.animate.shift(RIGHT),
-			r2.animate.shift(DOWN),
-			r1.animate.shift(DOWN+LEFT),
-			r3.animate.shift(DOWN),
-			w1.animate.shift(DOWN))
+		# self.play(
+		# 	bjt_npn.animate.shift(DOWN*0.5+LEFT),
+		# 	c.animate.shift(RIGHT),
+		# 	r2.animate.shift(DOWN),
+		# 	r1.animate.shift(DOWN+LEFT),
+		# 	r3.animate.shift(DOWN),
+		# 	w1.animate.shift(DOWN))
 		
-		g = Group(*cElems)
-		self.play(g.animate.scale(0.4).shift(LEFT+DOWN))
-		self.play(g.animate.scale(2).shift(LEFT+UP))
-		self.play(c.animate.shift(RIGHT))
+		# g = Group(*cElems)
+		# self.play(g.animate.scale(0.4).shift(LEFT+DOWN))
+		# self.play(g.animate.scale(2).shift(LEFT+UP))
+		# self.play(c.animate.shift(RIGHT))
 		
 		self.wait(0.1)

--- a/examples/test.py
+++ b/examples/test.py
@@ -6,66 +6,60 @@ class test(Scene):
 	def construct(self):
 		self.wait(0.1)
 
-		opamp = OpAmp().shift(DOWN*2).scale(0.5).update()
-		bjt = BJT_NPN().shift(UP*2).scale(0.5).update()
+		i1 = Inductor(reverse_points=True)
+		b = Battery()
+		c = Capacitor()
+		bjt_npn = BJT_NPN()
 
-		self.play(Create(opamp),Create(bjt), run_time=5)
+		bjt_npn.shift(UP*2).scale(0.5)
+		i1.shift(DOWN*2).scale(0.5)
+		b.shift(LEFT*3).rotate(PI/2).scale(0.5)
+		c.shift(RIGHT*3).rotate(-PI/2).scale(0.5)
 
-		# r1 = Battery()
-		# r2 = Resistor()
-		# c = Capacitor()
-		# bjt_npn = BJT_NPN()
+		hw1,vw1=connect_with_square_wire(c, 'left', bjt_npn, 'collector', 'y')
+		hw2,vw2=connect_with_square_wire(c, 'right', i1, 'right', 'x')
+		hw3,vw3=connect_with_square_wire(b, 'negative', i1, 'left', 'y')
+		hw4,vw4=connect_with_square_wire(b, 'positive', bjt_npn, 'emitter', 'x')
+		cElems = [bjt_npn,hw1,vw1,c,vw2,hw2,i1,hw3,vw3,b,vw4,hw4]
 
-
-		# bjt_npn.shift(UP*2).scale(0.5)
-		# r1.shift(DOWN*2).rotate(PI).scale(0.5)
-		# r2.shift(LEFT*3).rotate(PI/2).scale(0.5)
-		# c.shift(RIGHT*3).rotate(-PI/2).scale(0.5)
-
-		# hw1,vw1=connect_with_square_wire(c, 'left', bjt_npn, 'collector', 'y')
-		# hw2,vw2=connect_with_square_wire(c, 'right', r1, 'negative', 'x')
-		# hw3,vw3=connect_with_square_wire(r2, 'left', r1, 'positive', 'y')
-		# hw4,vw4=connect_with_square_wire(r2, 'right', bjt_npn, 'emitter', 'x')
-		# cElems = [bjt_npn,hw1,vw1,c,vw2,hw2,r1,hw3,vw3,r2,vw4,hw4]
-
-		# for cElem in cElems:
-		# 	cElem.update()
+		for cElem in cElems:
+			cElem.update()
 
 
-		# for wire in [hw1, vw1, hw2, vw2, hw3, vw3, hw4, vw4]:
-		# 	wire.scale(0.5)
-		# 	wire.update()
+		for wire in [hw1, vw1, hw2, vw2, hw3, vw3, hw4, vw4]:
+			wire.scale(0.5)
+			wire.update()
 
 			
-		# hw0, hw1 = split_wire(hw1, 0.2)
-		# hw0.bind_terminal('right', bjt_npn, 'collector', Y_AXIS)
-		# hw1.bind_terminal('left', bjt_npn, 'collector', Y_AXIS)
+		hw0, hw1 = split_wire(hw1, 0.2)
+		hw0.bind_terminal('right', bjt_npn, 'collector', Y_AXIS)
+		hw1.bind_terminal('left', bjt_npn, 'collector', Y_AXIS)
 
-		# r3 = Resistor()
-		# r3.rotate(-PI/2).scale(0.5).shift([hw0.get_terminal_coord('right')[0] - r3.get_terminal_coord('left')[0], 0, 0])
-		# w0 = connect_with_straight_wire(hw0, 'right', r3, 'left')
-		# w1 = Wire()
-		# w0=w0.scale(0.5)
-		# w1=w1.scale(0.5)
-		# w1.set_terminal_coordinate('left', r3.get_terminal_coord('right'))
-		# w1.set_terminal_coordinate('right', [r3.get_terminal_coord('right')[0], r1.get_center()[1], r3.get_terminal_coord('right')[2]])
+		r3 = Resistor()
+		r3.rotate(-PI/2).scale(0.5).shift([hw0.get_terminal_coord('right')[0] - r3.get_terminal_coord('left')[0], 0, 0])
+		w0 = connect_with_straight_wire(hw0, 'right', r3, 'left')
+		w1 = Wire()
+		w0=w0.scale(0.5)
+		w1=w1.scale(0.5)
+		w1.set_terminal_coordinate('left', r3.get_terminal_coord('right'))
+		w1.set_terminal_coordinate('right', [r3.get_terminal_coord('right')[0], i1.get_terminal_coord('left')[1], r3.get_terminal_coord('right')[2]])
 
-		# cElems = [bjt_npn,hw0,hw1,vw1,c,vw2,hw2,r1,hw3,vw3,r2,vw4,hw4, w0,r3,w1]
-		# for cElem in cElems:
-		# 	cElem.update()
-		# 	self.play(Create(cElem))
+		cElems = [bjt_npn,hw0,hw1,vw1,c,vw2,hw2,i1,hw3,vw3,b,vw4,hw4, w0,r3,w1]
+		for cElem in cElems:
+			cElem.update()
+			self.play(Create(cElem))
 
-		# self.play(
-		# 	bjt_npn.animate.shift(DOWN*0.5+LEFT),
-		# 	c.animate.shift(RIGHT),
-		# 	r2.animate.shift(DOWN),
-		# 	r1.animate.shift(DOWN+LEFT),
-		# 	r3.animate.shift(DOWN),
-		# 	w1.animate.shift(DOWN))
+		self.play(
+			bjt_npn.animate.shift(DOWN*0.5+LEFT),
+			c.animate.shift(RIGHT),
+			b.animate.shift(DOWN),
+			i1.animate.shift(DOWN+LEFT),
+			r3.animate.shift(DOWN),
+			w1.animate.shift(DOWN))
 		
-		# g = Group(*cElems)
-		# self.play(g.animate.scale(0.4).shift(LEFT+DOWN))
-		# self.play(g.animate.scale(2).shift(LEFT+UP))
-		# self.play(c.animate.shift(RIGHT))
+		g = Group(*cElems)
+		self.play(g.animate.scale(0.4).shift(LEFT+DOWN))
+		self.play(g.animate.scale(2).shift(LEFT+UP))
+		self.play(c.animate.shift(RIGHT))
 		
 		self.wait(0.1)

--- a/manim_hkn/__init__.py
+++ b/manim_hkn/__init__.py
@@ -1,6 +1,6 @@
 from manim import *
 
-from manim_hkn.cElements import Resistor, Capacitor, BJT_NPN, Wire, Battery, OpAmp
+from manim_hkn.cElements import Resistor, Capacitor, Inductor, BJT_NPN, Wire, Battery, OpAmp
 from manim_hkn.utils.circuitBuilder import connect_with_straight_wire, connect_with_square_wire, split_wire
 
 __all__ = [
@@ -8,6 +8,7 @@ __all__ = [
 	'BJT_NPN',
 	'Resistor',
 	'Capacitor',
+	'Inductor',
 	'Battery',
 	'Wire',
 	'connect_with_straight_wire',

--- a/manim_hkn/__init__.py
+++ b/manim_hkn/__init__.py
@@ -1,6 +1,6 @@
 from manim import *
 
-from manim_hkn.cElements import Resistor, Capacitor, Inductor, BJT_NPN, Wire, Battery, OpAmp
+from manim_hkn.cElements import Resistor, Capacitor, Inductor, BJT_NPN, Wire, Battery, OpAmp, Ground
 from manim_hkn.utils.circuitBuilder import connect_with_straight_wire, connect_with_square_wire, split_wire
 
 __all__ = [
@@ -10,6 +10,7 @@ __all__ = [
 	'Capacitor',
 	'Inductor',
 	'Battery',
+	'Ground',
 	'Wire',
 	'connect_with_straight_wire',
 	'connect_with_square_wire',

--- a/manim_hkn/__init__.py
+++ b/manim_hkn/__init__.py
@@ -1,12 +1,13 @@
 from manim import *
 
-from manim_hkn.cElements import Resistor, Capacitor, BJT_NPN, Wire, Battery
+from manim_hkn.cElements import Resistor, Capacitor, BJT_NPN, Wire, Battery, OpAmp
 from manim_hkn.utils.circuitBuilder import connect_with_straight_wire, connect_with_square_wire, split_wire
 
 __all__ = [
+	'OpAmp',
+	'BJT_NPN',
 	'Resistor',
 	'Capacitor',
-	'BJT_NPN',
 	'Battery',
 	'Wire',
 	'connect_with_straight_wire',

--- a/manim_hkn/cElements.py
+++ b/manim_hkn/cElements.py
@@ -16,19 +16,21 @@ import numpy as np
 class _CircuitElementTemplate(VMobject):
 	def __init__(self: "_CircuitElementTemplate",
 			  terminalCoords: dict[str, list[float]],
+			  reverse_points: bool = False,
 			  **kwargs) -> None:
 		kwargs['stroke_width'] 	= kwargs.get('stroke_width', 	15)
 		kwargs['color'] 		= kwargs.get('color', 			WHITE)
 		kwargs['joint_type'] 	= kwargs.get('joint_type', 		LineJointType.ROUND)
 		kwargs['cap_style'] 	= kwargs.get('cap_style', 		CapStyleType.ROUND)	
-
+		
 		self._terminal_scale_factor:float = 0.5
-
 		self._terminals:dict[str, Terminal] = {
 			terminal_name:Terminal(radius = kwargs['stroke_width'] * self._terminal_scale_factor, point = terminalCoords[terminal_name])
 			
 			for terminal_name in terminalCoords
 		}
+
+		self._reverse_points = reverse_points
 
 		VMobject.__init__(self,	**kwargs)
 		
@@ -37,6 +39,9 @@ class _CircuitElementTemplate(VMobject):
 		def _update_width(self:"_CircuitElementTemplate"):
 			VMobject.set_stroke(self, width=100.*list(self._terminals.values())[0].width / self._terminal_scale_factor)
 		self.add_updater(_update_width)
+	def generate_points(self:"_CircuitElementTemplate") -> None:
+		if self._reverse_points:
+			self.points = self.points[::-1]
 
 	# Set stroke override. With this, and the updater added to circuit elements in __init__, we enable scaling of an element to also scale the width accordingly, while also enabling scaling width in isolation.
 	def set_stroke(self:"_CircuitElementTemplate", *args, width:float = None, **kwargs) -> "_CircuitElementTemplate":
@@ -52,7 +57,7 @@ class _CircuitElementTemplate(VMobject):
 						radius:float = 1) -> None:
 		self._close_last_curve()
 		
-		num_components:int = 9
+		num_components:int = int(9 * abs(start_angle - angle) / TAU) + 1
 		d_theta:float = angle / (num_components - 1.0)
 
 		anchors:list[list[float]] = np.array(
@@ -83,9 +88,28 @@ class _CircuitElementTemplate(VMobject):
 				arrays[3][i]
 			)
 	def _add_geom_circle(	self:"_CircuitElementTemplate",
+							start_angle:float	= 0,
 							center:list[float]	= ORIGIN,
 							radius:float = 1) -> None:
-		self._add_geom_arc(radius=radius, center=center, angle=TAU)
+		self._add_geom_arc(start_angle, TAU, center, radius)
+	def _add_geom_elliptical_arc(	self:"_CircuitElementTemplate",
+									start_angle:float	= 0,
+									angle:float 		= PI / 2,
+									center:list[float]	= ORIGIN,
+									width:float = 2,
+									height:float = 1) -> None:
+		arc_start_index = len(self.points)
+		self._add_geom_arc(start_angle, angle, ORIGIN, radius = 0.5)
+		for i in range(arc_start_index, len(self.points)):
+			self.points[i][0] *= width
+			self.points[i][1] *= height
+			self.points[i] += center
+	def _add_geom_ellipse(	self:"_CircuitElementTemplate",
+							start_angle:float	= 0,
+							center:list[float]	= ORIGIN,
+							width:float = 2,
+							height:float = 1) -> None:
+		self._add_geom_elliptical_arc(start_angle, TAU, center, width, height)
 	def _add_geom_linear_path(	self:"_CircuitElementTemplate",
 						   		vertices:list[list[float]]) -> None:
 		self.start_new_path(np.array(vertices[0]))
@@ -194,7 +218,7 @@ class OpAmp(_CircuitElementTemplate):
 			pointer_notch_depth_ratio = 0
 		)
 		self._add_geom_polygram(*self._polygram)
-
+		super().generate_points()
 
 class BJT_NPN(_CircuitElementTemplate):
 	# Defines how far down the emmitter trace on the diagram the arrow tip is located
@@ -240,6 +264,7 @@ class BJT_NPN(_CircuitElementTemplate):
 			length = BJT_NPN._ARROW_LENGTH_RATIO * self.stroke_width / 100,
 			pointer_notch_depth_ratio = 0
 		)
+		super().generate_points()
 
 class Capacitor(_CircuitElementTemplate):
 	# This ratio is used for the following geometric equality: <Capacitor Height> = 2/3 * HEIGHT_RATIO * <Capacitor Width>
@@ -272,23 +297,40 @@ class Capacitor(_CircuitElementTemplate):
 		
 	def generate_points(self:"Capacitor") -> None:
 		self._add_geom_polygram(*self._polygram)
+		super().generate_points()
 
 class Inductor(_CircuitElementTemplate):
-	def __init__(self:"Resistor", **kwargs) -> None:
+	# This ratio is used for the following geometric equality: <Inductor Width> = 2 * SPREAD_RATIO * <Inductor Height>
+	# In other words, this is defined by SPREAD_RATIO = 0.5 * <Inductor Width> / <Inductor Height
+	SPREAD_RATIO:float = 1.6
+	# Width of the ellipses forming the upper half of the inductor
+	UPPER_ELLIPSE_SPREAD:float = 1.75
+	def __init__(self:"Inductor", **kwargs) -> None:
 		# Generating vertices for Resistor
-		self._add_geom_polygram:list[list[list[float]]] = [
-			[[Resistor.SPREAD_RATIO*(-2),  0, 0],[Resistor.SPREAD_RATIO*(2),  0, 0]]
+		self._polygram:list[list[list[float]]] = [
+			[[ -2 * Inductor.SPREAD_RATIO,  0, 0],[-1.5 * Inductor.SPREAD_RATIO,  0, 0]],
+			[[1.5 * Inductor.SPREAD_RATIO,  0, 0],[   2 * Inductor.SPREAD_RATIO,  0, 0]]
 		]
 		super().__init__(
 			terminalCoords={
-				'left'	: self._vertices[0],
-				'right'	: self._vertices[-1]
+				'left'	: self._polygram[0][0],
+				'right'	: self._polygram[1][1]
 			},
 			**kwargs
 		)
 	
-	def generate_points(self:"Resistor") -> None:
-		self._add_geom_linear_path(self._vertices)
+	def generate_points(self:"Inductor") -> None:
+		self._add_geom_linear_path(self._polygram[0])
+
+		loop_width:float = (self._polygram[1][0][0] - self._polygram[0][1][0] - Inductor.UPPER_ELLIPSE_SPREAD) / 3
+
+		for i in range(-1,1+1,1):
+			self._add_geom_elliptical_arc(start_angle=PI, angle=-PI, center=RIGHT * (i - 0.5) * loop_width, width=Inductor.UPPER_ELLIPSE_SPREAD, height=2)
+			self._add_geom_elliptical_arc(start_angle=0, angle=-PI, center=RIGHT * (i - 0.0) * loop_width, width=Inductor.UPPER_ELLIPSE_SPREAD - loop_width, height=1.4)
+
+		self._add_geom_elliptical_arc(start_angle=PI, angle=-PI, center=RIGHT * 1.5 * loop_width, width=Inductor.UPPER_ELLIPSE_SPREAD, height=2)
+		self._add_geom_linear_path(self._polygram[1])
+		super().generate_points()
 
 class Battery(_CircuitElementTemplate):
 	def __init__(self:"Battery", **kwargs) -> None:
@@ -315,6 +357,7 @@ class Battery(_CircuitElementTemplate):
 		
 	def generate_points(self) -> None:
 		self._add_geom_polygram(*self._polygram)
+		super().generate_points()
 
 class Resistor(_CircuitElementTemplate):
 	# This ratio is used for the following geometric equality: <Resistor Width> = 2 * SPREAD_RATIO * <Resistor Height>
@@ -325,11 +368,11 @@ class Resistor(_CircuitElementTemplate):
 		# Generating vertices for Resistor
 		self._vertices:list[list[float]] = [[Resistor.SPREAD_RATIO*(-2),  0, 0]]
 		for i in range(-1, 1+1, 1):
-			self._vertices.extend([[Resistor.SPREAD_RATIO*(i-0.5),  0, 0],
-				   			[Resistor.SPREAD_RATIO*(i-0.25),  1, 0],
-							[Resistor.SPREAD_RATIO*(i+0.25), -1, 0],
-							[Resistor.SPREAD_RATIO*(i+0.5),  0, 0]])
-		self._vertices.append([Resistor.SPREAD_RATIO*(2),  0, 0])
+			self._vertices.extend([ [Resistor.SPREAD_RATIO*(i-0.5),  0, 0],
+									[Resistor.SPREAD_RATIO*(i-0.25),  1, 0],
+									[Resistor.SPREAD_RATIO*(i+0.25), -1, 0],
+									[Resistor.SPREAD_RATIO*(i+0.5),  0, 0]])
+		self._vertices.append(		[Resistor.SPREAD_RATIO*(2),  0, 0])
 
 		super().__init__(
 			terminalCoords={
@@ -341,6 +384,7 @@ class Resistor(_CircuitElementTemplate):
 	
 	def generate_points(self:"Resistor") -> None:
 		self._add_geom_linear_path(self._vertices)
+		super().generate_points()
 
 class Wire(_CircuitElementTemplate):
 	def __init__(self:"Wire", **kwargs) -> None:
@@ -389,11 +433,10 @@ class Wire(_CircuitElementTemplate):
 	def generate_points(self:"Wire") -> None:
 		self.clear_points()
 		self._add_geom_linear_path([self._target_coordinates[key] for key in self._terminals.keys()])
+		super().generate_points()
 
 	def set_terminal_coordinate(self:"Wire", key:str, coord:list[float]) -> "Wire":
 		self._target_coordinates[key] = coord
-		print(self._target_coordinates[key],
-			self._terminals[key].get_center())
 		self._terminals[key].shift(
 			self._target_coordinates[key] - 
 			self._terminals[key].get_center())

--- a/manim_hkn/cElements.py
+++ b/manim_hkn/cElements.py
@@ -273,6 +273,23 @@ class Capacitor(_CircuitElementTemplate):
 	def generate_points(self:"Capacitor") -> None:
 		self._add_geom_polygram(*self._polygram)
 
+class Inductor(_CircuitElementTemplate):
+	def __init__(self:"Resistor", **kwargs) -> None:
+		# Generating vertices for Resistor
+		self._add_geom_polygram:list[list[list[float]]] = [
+			[[Resistor.SPREAD_RATIO*(-2),  0, 0],[Resistor.SPREAD_RATIO*(2),  0, 0]]
+		]
+		super().__init__(
+			terminalCoords={
+				'left'	: self._vertices[0],
+				'right'	: self._vertices[-1]
+			},
+			**kwargs
+		)
+	
+	def generate_points(self:"Resistor") -> None:
+		self._add_geom_linear_path(self._vertices)
+
 class Battery(_CircuitElementTemplate):
 	def __init__(self:"Battery", **kwargs) -> None:
 		self._polygram:list[list[list[float]]] = [

--- a/manim_hkn/cElements.py
+++ b/manim_hkn/cElements.py
@@ -359,6 +359,34 @@ class Battery(_CircuitElementTemplate):
 		self._add_geom_polygram(*self._polygram)
 		super().generate_points()
 
+
+class Ground(_CircuitElementTemplate):
+	def __init__(self:"Battery", **kwargs) -> None:
+		self._polygram:list[list[list[float]]] = [
+			[
+				[0,0,0],
+				[ 0,-0.5,0],
+				[-1,-0.5,0],
+				[+1,-0.5,0],
+			],[
+				[-0.66,-0.9,0],
+				[+0.66,-0.9,0],
+			],[
+				[-0.33,-1.3,0],
+				[+0.33,-1.3,0],
+			]
+		]
+		super().__init__(
+			terminalCoords={
+				'ground'	: self._polygram[1][0]
+			},
+			**kwargs
+		)
+		
+	def generate_points(self) -> None:
+		self._add_geom_polygram(*self._polygram)
+		super().generate_points()
+
 class Resistor(_CircuitElementTemplate):
 	# This ratio is used for the following geometric equality: <Resistor Width> = 2 * SPREAD_RATIO * <Resistor Height>
 	# In other words, this is defined by SPREAD_RATIO = 0.5 * <Resistor Width> / <Resistor Height

--- a/manim_hkn/cElements.py
+++ b/manim_hkn/cElements.py
@@ -152,6 +152,50 @@ class _CircuitElementTemplate(VMobject):
 			*args, **kwargs
 		)
 
+class OpAmp(_CircuitElementTemplate):
+	def __init__(self:"OpAmp", non_inverting_terminal_on_top:bool = True, include_bias_terminals:bool = False, **kwargs) -> None:
+		triangle_width:float = 3.5 / np.sqrt(3)
+		self._polygram:list[list[list[float]]] = [
+			# input terminals
+			[[-1.75, 1,0],[-2.75, 1, 0]],
+			[[-1.75,-1,0],[-2.75,-1, 0]],
+			# output terminal
+			[[ 1.75, 0,0],[ 2.75, 0, 0]],
+			# symbols
+			[[-1.25, -1.25 + 2.00 * non_inverting_terminal_on_top, 0], [-1.25, -0.75 + 2.00 * non_inverting_terminal_on_top, 0]],
+			[[-1.50, -1.00 + 2.00 * non_inverting_terminal_on_top, 0], [-1.00, -1.00 + 2.00 * non_inverting_terminal_on_top, 0]],
+			[[-1.50,  1.00 - 2.00 * non_inverting_terminal_on_top, 0], [-1.00,  1.00 - 2.00 * non_inverting_terminal_on_top, 0]],
+		]
+		# bias terminals
+		if include_bias_terminals:
+			self._polygram[3:3] = [
+				[[0, triangle_width/2, 0],[0, triangle_width/2 + 1, 0]],
+				[[0,-triangle_width/2, 0],[0, -triangle_width/2 - 1, 0]]
+			]
+
+		super().__init__(
+			terminalCoords={
+				'non-inverting input'	: self._polygram[0][1],
+				'inverting input'		: self._polygram[1][1],
+				'output'				: self._polygram[2][1]
+			} | ({
+				'V+'					: self._polygram[3][1],
+				'V-'					: self._polygram[4][1]
+			} if include_bias_terminals else {}),
+			**kwargs
+		)
+
+	def generate_points(self:"OpAmp") -> None:
+		self._add_geom_pointer(
+			tip_coord	 = self._polygram[2][0],
+			target_coord = self._polygram[2][1],
+			width  = (self._polygram[2][0][0] - self._polygram[0][0][0]) * 2 / np.sqrt(3),
+			length =  self._polygram[2][0][0] - self._polygram[0][0][0],
+			pointer_notch_depth_ratio = 0
+		)
+		self._add_geom_polygram(*self._polygram)
+
+
 class BJT_NPN(_CircuitElementTemplate):
 	# Defines how far down the emmitter trace on the diagram the arrow tip is located
 	_ARROW_DIST_RATIO:float = 0.7

--- a/manim_hkn/terminal.py
+++ b/manim_hkn/terminal.py
@@ -11,7 +11,7 @@ class Terminal(Dot):
 		kwargs['radius'] 			= kwargs.get('radius', 1) / 30.
 		kwargs['stroke_width'] 		= kwargs.get('stroke_width', 0)
 		kwargs['fill_opacity'] 		= kwargs.get('fill_opacity', 0)
-		kwargs['stroke_opacity'] 	= kwargs.get('stroke_opacity', 0)
+		kwargs['stroke_opacity'] 	= kwargs.get('stroke_opacity', 1)
 		kwargs['color']		 		= kwargs.get('color', BLUE.invert()).invert()
 
 		self._terminal_center:Point3D = ORIGIN


### PR DESCRIPTION
- Added Inductor and OpAmp Circuit Elements
- Added _add_geom functionality for ellipses and partial elliptical arcs -> used in Inductor geometry creation
- Enabled flipping of animation order for creation of circuit elements
- These components will be needed for demo: OpAmp for integrator demo, and Inductor for RLC demo